### PR TITLE
fix: allow missing native feed URL in add feed workflow

### DIFF
--- a/.github/workflows/add_feed.yml
+++ b/.github/workflows/add_feed.yml
@@ -41,7 +41,7 @@ jobs:
           echo "prev_config=$PREV" >> $GITHUB_OUTPUT
           bun run src/add-smart.ts "${{ steps.url.outputs.url }}" 2>&1 | tee /tmp/add-smart.log
           OUTPUT=$(cat /tmp/add-smart.log)
-          NATIVE_URL=$(echo "$OUTPUT" | grep '^native_feed_url=' | sed 's/^native_feed_url=//')
+          NATIVE_URL=$(echo "$OUTPUT" | grep '^native_feed_url=' | sed 's/^native_feed_url=//' || true)
           if [ -n "$NATIVE_URL" ]; then
             echo "native_url=$NATIVE_URL" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
## Summary

Fixes the Add Feed workflow failing after successfully adding GitHub Releases feeds.

When add-smart.ts adds a GitHub Releases feed, it does not print native_feed_url. The workflow currently extracts native_feed_url with grep while running under set -eo pipefail. If no native feed URL is present, grep exits with code 1 and stops the job before README update, commit, and issue comment.

## Changes

- Make native_feed_url extraction optional by allowing the grep pipeline to return no match.

## Verification

Verified in my fork with https://github.com/heygen-com/hyperframes. Before this change, the feed files were generated successfully but the workflow failed immediately after because native_feed_url was absent. After the change, the workflow continued through README update, committed the generated feed files, commented on the issue, and closed it.